### PR TITLE
VDB Points Scatter algorithms with OpenVDB Scatter SOP support

### DIFF
--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -353,6 +353,7 @@ INCLUDE_NAMES := \
     points/PointDataGrid.h \
     points/PointDelete.h \
     points/PointGroup.h \
+    points/PointScatter.h \
     points/StreamCompression.h \
     tools/ChangeBackground.h \
     tools/Clip.h \
@@ -519,6 +520,7 @@ UNITTEST_SRC_NAMES := \
     unittest/TestPointGroup.cc \
     unittest/TestPointIndexGrid.cc \
     unittest/TestPointPartitioner.cc \
+    unittest/TestPointScatter.cc \
     unittest/TestPointsToMask.cc \
     unittest/TestPoissonSolver.cc \
     unittest/TestPotentialFlow.cc \

--- a/openvdb/points/PointScatter.h
+++ b/openvdb/points/PointScatter.h
@@ -99,7 +99,8 @@ template<
     typename GridT,
     typename RandGenT = std::mt19937,
     typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
-    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename PointDataGridT = Grid<
+        typename points::TreeConverter<typename GridT::TreeType>::Type>,
     typename InterrupterT = util::NullInterrupter>
 inline typename PointDataGridT::Ptr
 uniformPointScatter(const GridT& grid,
@@ -127,7 +128,8 @@ template<
     typename GridT,
     typename RandGenT = std::mt19937,
     typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
-    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename PointDataGridT = Grid<
+        typename points::TreeConverter<typename GridT::TreeType>::Type>,
     typename InterrupterT = util::NullInterrupter>
 inline typename PointDataGridT::Ptr
 denseUniformPointScatter(const GridT& grid,
@@ -158,7 +160,8 @@ template<
     typename GridT,
     typename RandGenT = std::mt19937,
     typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
-    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename PointDataGridT = Grid<
+        typename points::TreeConverter<typename GridT::TreeType>::Type>,
     typename InterrupterT = util::NullInterrupter>
 inline typename PointDataGridT::Ptr
 nonUniformPointScatter(const GridT& grid,
@@ -302,8 +305,9 @@ uniformPointScatter(const GridT& grid,
     const Index64 remainder = count - (pointsPerVoxel * voxelCount);
 
     if (remainder == 0) {
-        return denseUniformPointScatter<GridT, RandGenT, PositionArrayT, PointDataGridT, InterrupterT>
-            (grid, pointsPerVoxel, seed, spread, interrupter);
+        return denseUniformPointScatter<
+            GridT, RandGenT, PositionArrayT, PointDataGridT, InterrupterT>(
+                grid, pointsPerVoxel, seed, spread, interrupter);
     }
 
     std::vector<Index64> voxelOffsets, values;

--- a/openvdb/points/PointScatter.h
+++ b/openvdb/points/PointScatter.h
@@ -1,0 +1,566 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+//
+/// @author Nick Avramoussis
+///
+/// @file PointScatter.h
+///
+/// @brief Various point scattering methods for generating VDB Points.
+///
+///  All random number calls are made to the same generator to produce
+///  temporarily consistent results in relation to the provided seed. This
+///  comes with some multi-threaded performance trade-offs.
+///
+#ifndef OPENVDB_POINTS_POINT_SCATTER_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_SCATTER_HAS_BEEN_INCLUDED
+
+#include <type_traits>
+#include <algorithm>
+#include <thread>
+#include <random>
+
+#include <openvdb/openvdb.h>
+#include <openvdb/Types.h>
+#include <openvdb/tree/LeafManager.h>
+#include <openvdb/tools/Prune.h>
+#include <openvdb/util/NullInterrupter.h>
+
+#include "AttributeArray.h"
+#include "PointCount.h"
+#include "PointDataGrid.h"
+
+#include <tbb/parallel_sort.h>
+#include <tbb/parallel_for.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+/// @brief The free functions depend on the following class:
+///
+/// The @c InterrupterT template argument below refers to any class
+/// with the following interface:
+/// @code
+/// class Interrupter {
+///   ...
+/// public:
+///   void start(const char* name = NULL)// called when computations begin
+///   void end()                         // called when computations end
+///   bool wasInterrupted(int percent=-1)// return true to break computation
+///};
+/// @endcode
+///
+/// @note If no template argument is provided for this InterrupterT
+/// the util::NullInterrupter is used which implies that all
+/// interrupter calls are no-ops (i.e. incurs no computational overhead).
+
+
+/// @brief Uniformly scatter a total amount of points in active regions
+///
+/// @param grid         A source grid. The resulting PointDataGrid will copy this grids
+///                     transform and scatter in its active voxelized topology.
+/// @param count        The total number of points to scatter
+/// @param seed         A seed for the RandGenT
+/// @param spread       The spread of points as a scale from each voxels center. A value of
+///                     1.0f indicates points can be placed anywhere within the voxel, where
+///                     as a value of 0.0f will force all points to be created exactly at the
+///                     centers of each voxel.
+/// @param interrupter  An optional interrupter
+/// @note returns the scattered PointDataGrid
+template<
+    typename GridT,
+    typename RandGenT = std::mt19937,
+    typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
+    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename InterrupterT = util::NullInterrupter>
+inline typename PointDataGridT::Ptr
+uniformPointScatter(const GridT& grid,
+                    const Index64 count,
+                    const unsigned int seed = 0,
+                    const float spread = 1.0f,
+                    InterrupterT* interrupter = nullptr);
+
+/// @brief Uniformly scatter a fixed number of points per active voxel. If the pointsPerVoxel
+///        value provided is a fractional value, each voxel calculates a delta value of
+///        how likely it is to contain an extra point.
+///
+/// @param grid            A source grid. The resulting PointDataGrid will copy this grids
+///                        transform and scatter in its active voxelized topology.
+/// @param pointsPerVoxel  The number of points to scatter per voxel
+/// @param seed            A seed for the RandGenT
+/// @param spread          The spread of points as a scale from each voxels center. A value of
+///                        1.0f indicates points can be placed anywhere within the voxel, where
+///                        as a value of 0.0f will force all points to be created exactly at the
+///                        centers of each voxel.
+/// @param interrupter     An optional interrupter
+/// @note returns the scattered PointDataGrid
+
+template<
+    typename GridT,
+    typename RandGenT = std::mt19937,
+    typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
+    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename InterrupterT = util::NullInterrupter>
+inline typename PointDataGridT::Ptr
+denseUniformPointScatter(const GridT& grid,
+                         const float pointsPerVoxel,
+                         const unsigned int seed = 0,
+                         const float spread = 1.0f,
+                         InterrupterT* interrupter = nullptr);
+
+/// @brief Non uniformly scatter points per active voxel. The pointsPerVoxel value is used
+///        to weight each grids cell value to compute a fixed number of points for every
+///        active voxel. If the computed result is a fractional value, each voxel calculates
+///        a delta value of how likely it is to contain an extra point.
+///
+/// @param grid            A source grid. The resulting PointDataGrid will copy this grids
+///                        transform, voxelized topology and use its values to compute a
+///                        target points per voxel. The grids ValueType must be convertible
+///                        to a scalar value. Only active and larger than zero values will
+///                        contain points.
+/// @param pointsPerVoxel  The number of points to scatter per voxel
+/// @param seed            A seed for the RandGenT
+/// @param spread          The spread of points as a scale from each voxels center. A value of
+///                        1.0f indicates points can be placed anywhere within the voxel, where
+///                        as a value of 0.0f will force all points to be created exactly at the
+///                        centers of each voxel.
+/// @param interrupter     An optional interrupter
+/// @note returns the scattered PointDataGrid
+template<
+    typename GridT,
+    typename RandGenT = std::mt19937,
+    typename PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>,
+    typename PointDataGridT = Grid<typename points::TreeConverter<typename GridT::TreeType>::Type>,
+    typename InterrupterT = util::NullInterrupter>
+inline typename PointDataGridT::Ptr
+nonUniformPointScatter(const GridT& grid,
+                       const float pointsPerVoxel,
+                       const unsigned int seed = 0,
+                       const float spread = 1.0f,
+                       InterrupterT* interrupter = nullptr);
+
+
+////////////////////////////////////////
+
+
+namespace point_scatter_internal
+{
+
+/// @brief initialise the topology of a PointDataGrid and ensure
+/// everything is voxelized
+/// @parm grid   The source grid from which to base the topology generation
+template<typename PointDataGridT, typename GridT>
+inline typename PointDataGridT::Ptr
+initialisePointTopology(const GridT& grid)
+{
+    typename PointDataGridT::Ptr points(new PointDataGridT);
+    points->setTransform(grid.transform().copy());
+    points->topologyUnion(grid);
+    if (points->tree().hasActiveTiles()) {
+        points->tree().voxelizeActiveTiles();
+    }
+
+    return points;
+}
+
+/// @brief Generate random point positions for a leaf node
+/// @parm leaf       The leaf node to initialize
+/// @parm descriptor The descriptor containing the position type
+/// @parm count      The number of points to generate
+/// @parm spread     The spread of points from the voxel center
+/// @parm rand01     The random number generator, expected to produce floating point
+///                  values between 0 and 1.
+template<typename PositionType,
+         typename CodecT,
+         typename RandGenT,
+         typename LeafNodeT>
+inline void
+generatePositions(LeafNodeT& leaf,
+                  const AttributeSet::Descriptor::Ptr& descriptor,
+                  const Index64& count,
+                  const float spread,
+                  RandGenT& rand01)
+{
+    using PositionTraits = VecTraits<PositionType>;
+    using ValueType = typename PositionTraits::ElementType;
+    using PositionWriteHandle = AttributeWriteHandle<PositionType, CodecT>;
+
+    leaf.initializeAttributes(descriptor, count);
+
+    // directly expand to avoid needlessly setting uniform values in the
+    // write handle
+    auto& array = leaf.attributeArray(0);
+    array.expand(/*fill*/false);
+
+    PositionWriteHandle pHandle(array, /*expand*/false);
+    PositionType P;
+    for (Index64 index = 0; index < count; ++index) {
+        P[0] = (spread * (rand01() - ValueType(0.5)));
+        P[1] = (spread * (rand01() - ValueType(0.5)));
+        P[2] = (spread * (rand01() - ValueType(0.5)));
+        pHandle.set(index, P);
+    }
+}
+
+} // namespace point_scatter_internal
+
+
+////////////////////////////////////////
+
+
+template<
+    typename GridT,
+    typename RandGenT,
+    typename PositionArrayT,
+    typename PointDataGridT,
+    typename InterrupterT>
+inline typename PointDataGridT::Ptr
+uniformPointScatter(const GridT& grid,
+                    const Index64 count,
+                    const unsigned int seed,
+                    const float spread,
+                    InterrupterT* interrupter)
+{
+    using PositionType = typename PositionArrayT::ValueType;
+    using PositionTraits = VecTraits<PositionType>;
+    using ValueType = typename PositionTraits::ElementType;
+    using CodecType = typename PositionArrayT::Codec;
+
+    using RandomGenerator = math::Rand01<ValueType, RandGenT>;
+
+    using TreeType = typename PointDataGridT::TreeType;
+    using LeafNodeType = typename TreeType::LeafNodeType;
+    using LeafManagerT = tree::LeafManager<TreeType>;
+
+    struct Local
+    {
+        /// @brief Get the prefixed voxel counts for each leaf node with an
+        /// additional value to represent the end voxel count.
+        /// See also LeafManager::getPrefixSum()
+        static void getPrefixSum(LeafManagerT& leafManager,
+                                 std::vector<Index64>& offsets)
+        {
+            Index64 offset = 0;
+            offsets.reserve(leafManager.leafCount() + 1);
+            offsets.push_back(0);
+            const auto leafRange = leafManager.leafRange();
+            for (auto leaf = leafRange.begin(); leaf; ++leaf) {
+                offset += leaf->onVoxelCount();
+                offsets.push_back(offset);
+            }
+        }
+    };
+
+    static_assert(PositionTraits::IsVec && PositionTraits::Size == 3,
+                  "Invalid Position Array type.");
+
+    if (spread < 0.0f || spread > 1.0f) {
+        OPENVDB_THROW(ValueError, "Spread must be between 0 and 1.");
+    }
+
+    if (interrupter) interrupter->start("Uniform scattering with fixed point count");
+
+    typename PointDataGridT::Ptr points =
+        point_scatter_internal::initialisePointTopology<PointDataGridT>(grid);
+    TreeType& tree = points->tree();
+    if (!tree.cbeginLeaf()) return points;
+
+    LeafManagerT leafManager(tree);
+    const Index64 voxelCount = leafManager.activeLeafVoxelCount();
+    assert(voxelCount != 0);
+
+    const double pointsPerVolume = double(count) / double(voxelCount);
+    const Index32 pointsPerVoxel = static_cast<Index32>(math::RoundDown(pointsPerVolume));
+    const Index64 remainder = count - (pointsPerVoxel * voxelCount);
+
+    if (remainder == 0) {
+        return denseUniformPointScatter<GridT, RandGenT, PositionArrayT, PointDataGridT, InterrupterT>
+            (grid, pointsPerVoxel, seed, spread, interrupter);
+    }
+
+    std::vector<Index64> voxelOffsets, values;
+    std::thread worker(&Local::getPrefixSum, std::ref(leafManager), std::ref(voxelOffsets));
+
+    {
+        math::RandInt<Index64, RandGenT> gen(seed, 0, voxelCount-1);
+        values.reserve(remainder);
+        for (Index64 i = 0; i < remainder; ++i) values.emplace_back(gen());
+    }
+
+    worker.join();
+
+    if (util::wasInterrupted<InterrupterT>(interrupter)) {
+        tree.clear();
+        return points;
+    }
+
+    tbb::parallel_sort(values.begin(), values.end());
+
+    leafManager.foreach([&voxelOffsets, &values](LeafNodeType& leaf, const size_t idx) {
+        const Index64 lowerOffset = voxelOffsets[idx]; // inclusive
+        const Index64 upperOffset = voxelOffsets[idx + 1]; // exclusive
+        assert(upperOffset > lowerOffset);
+
+        const auto valuesEnd = values.end();
+        auto lower = std::lower_bound(values.begin(), valuesEnd, lowerOffset);
+
+        auto* const data = leaf.buffer().data();
+        auto iter = leaf.beginValueOn();
+
+        Index32 currentOffset(0);
+        while (lower != valuesEnd) {
+            const Index64 vId = *lower;
+            if (vId >= upperOffset) break;
+
+            const Index32 nextOffset = Index32(vId - lowerOffset);
+            iter.increment(nextOffset - currentOffset);
+            currentOffset = nextOffset;
+            assert(iter);
+
+            auto& value = data[iter.pos()];
+            value = value + 1; // no += operator support
+            ++lower;
+        }
+    });
+
+    voxelOffsets.clear();
+    values.clear();
+
+    const AttributeSet::Descriptor::Ptr descriptor =
+        AttributeSet::Descriptor::create(PositionArrayT::attributeType());
+    RandomGenerator rand01(seed);
+
+    const auto leafRange = leafManager.leafRange();
+    auto leaf = leafRange.begin();
+    for (; leaf; ++leaf) {
+        if (util::wasInterrupted<InterrupterT>(interrupter)) break;
+        Index32 offset(0);
+        for (auto iter = leaf->beginValueAll(); iter; ++iter) {
+            if (iter.isValueOn()) {
+                const Index32 value = pointsPerVolume + Index32(*iter);
+                if (value == 0) leaf->setValueOff(iter.pos());
+                else            offset += value;
+            }
+            // @note can't use iter.setValue(offset) on point grids
+            leaf->setOffsetOnly(iter.pos(), offset);
+        }
+
+        if (offset != 0) {
+            point_scatter_internal::generatePositions<PositionType, CodecType>
+                (*leaf, descriptor, offset, spread, rand01);
+        }
+    }
+
+    // if interrupted, remove remaining leaf nodes
+    const bool prune(leaf || pointsPerVoxel == 0);
+    for (; leaf; ++leaf) leaf->setValuesOff();
+
+    if (prune) tools::pruneInactive(tree);
+    if (interrupter) interrupter->end();
+    return points;
+}
+
+
+////////////////////////////////////////
+
+
+template<
+    typename GridT,
+    typename RandGenT,
+    typename PositionArrayT,
+    typename PointDataGridT,
+    typename InterrupterT>
+inline typename PointDataGridT::Ptr
+denseUniformPointScatter(const GridT& grid,
+                         const float pointsPerVoxel,
+                         const unsigned int seed,
+                         const float spread,
+                         InterrupterT* interrupter)
+{
+    using PositionType = typename PositionArrayT::ValueType;
+    using PositionTraits = VecTraits<PositionType>;
+    using ValueType = typename PositionTraits::ElementType;
+    using CodecType = typename PositionArrayT::Codec;
+
+    using RandomGenerator = math::Rand01<ValueType, RandGenT>;
+
+    using TreeType = typename PointDataGridT::TreeType;
+
+    static_assert(PositionTraits::IsVec && PositionTraits::Size == 3,
+                  "Invalid Position Array type.");
+
+    if (pointsPerVoxel < 0.0f) {
+        OPENVDB_THROW(ValueError, "Points per voxel must not be less than zero.");
+    }
+
+    if (spread < 0.0f || spread > 1.0f) {
+        OPENVDB_THROW(ValueError, "Spread must be between 0 and 1.");
+    }
+
+    if (interrupter) interrupter->start("Dense uniform scattering with fixed point count");
+
+    typename PointDataGridT::Ptr points =
+        point_scatter_internal::initialisePointTopology<PointDataGridT>(grid);
+    TreeType& tree = points->tree();
+    auto leafIter = tree.beginLeaf();
+    if (!leafIter) return points;
+
+    const Index32 pointsPerVoxelInt = math::Floor(pointsPerVoxel);
+    const double delta = pointsPerVoxel - float(pointsPerVoxelInt);
+    const bool fractional = !math::isApproxZero(delta, 1.0e-6);
+    const bool fractionalOnly = pointsPerVoxelInt == 0;
+
+    const AttributeSet::Descriptor::Ptr descriptor =
+        AttributeSet::Descriptor::create(PositionArrayT::attributeType());
+    RandomGenerator rand01(seed);
+
+    for (; leafIter; ++leafIter) {
+        if (util::wasInterrupted<InterrupterT>(interrupter)) break;
+        Index32 offset(0);
+        for (auto iter = leafIter->beginValueAll(); iter; ++iter) {
+            if (iter.isValueOn()) {
+                offset += pointsPerVoxelInt;
+                if (fractional && rand01() < delta) ++offset;
+                else if (fractionalOnly) leafIter->setValueOff(iter.pos());
+            }
+            // @note can't use iter.setValue(offset) on point grids
+            leafIter->setOffsetOnly(iter.pos(), offset);
+        }
+
+        if (offset != 0) {
+            point_scatter_internal::generatePositions<PositionType, CodecType>
+                (*leafIter, descriptor, offset, spread, rand01);
+        }
+    }
+
+    // if interrupted, remove remaining leaf nodes
+    const bool prune(leafIter || fractionalOnly);
+    for (; leafIter; ++leafIter) leafIter->setValuesOff();
+
+    if (prune) tools::pruneInactive(tree);
+    if (interrupter) interrupter->end();
+    return points;
+}
+
+
+////////////////////////////////////////
+
+
+template<
+    typename GridT,
+    typename RandGenT,
+    typename PositionArrayT,
+    typename PointDataGridT,
+    typename InterrupterT>
+inline typename PointDataGridT::Ptr
+nonUniformPointScatter(const GridT& grid,
+                       const float pointsPerVoxel,
+                       const unsigned int seed,
+                       const float spread,
+                       InterrupterT* interrupter)
+{
+    using PositionType = typename PositionArrayT::ValueType;
+    using PositionTraits = VecTraits<PositionType>;
+    using ValueType = typename PositionTraits::ElementType;
+    using CodecType = typename PositionArrayT::Codec;
+
+    using RandomGenerator = math::Rand01<ValueType, RandGenT>;
+
+    using TreeType = typename PointDataGridT::TreeType;
+
+    static_assert(PositionTraits::IsVec && PositionTraits::Size == 3,
+                  "Invalid Position Array type.");
+    static_assert(std::is_arithmetic<typename GridT::ValueType>::value,
+                  "Scalar grid type required for weighted voxel scattering.");
+
+    if (pointsPerVoxel < 0.0f) {
+        OPENVDB_THROW(ValueError, "Points per voxel must not be less than zero.");
+    }
+
+    if (spread < 0.0f || spread > 1.0f) {
+        OPENVDB_THROW(ValueError, "Spread must be between 0 and 1.");
+    }
+
+    if (interrupter) interrupter->start("Non-uniform scattering with local point density");
+
+    typename PointDataGridT::Ptr points =
+        point_scatter_internal::initialisePointTopology<PointDataGridT>(grid);
+    TreeType& tree = points->tree();
+    auto leafIter = tree.beginLeaf();
+    if (!leafIter) return points;
+
+    const AttributeSet::Descriptor::Ptr descriptor =
+        AttributeSet::Descriptor::create(PositionArrayT::attributeType());
+    RandomGenerator rand01(seed);
+    const auto accessor = grid.getConstAccessor();
+
+    for (; leafIter; ++leafIter) {
+        if (util::wasInterrupted<InterrupterT>(interrupter)) break;
+        Index32 offset(0);
+        for (auto iter = leafIter->beginValueAll(); iter; ++iter) {
+            if (iter.isValueOn()) {
+                double fractional =
+                    double(accessor.getValue(iter.getCoord())) * pointsPerVoxel;
+                fractional = std::max(0.0, fractional);
+                int count = int(fractional);
+                if (rand01() < (fractional - double(count))) ++count;
+                else if (count == 0) leafIter->setValueOff(iter.pos());
+                offset += count;
+            }
+            // @note can't use iter.setValue(offset) on point grids
+            leafIter->setOffsetOnly(iter.pos(), offset);
+        }
+
+        if (offset != 0) {
+            point_scatter_internal::generatePositions<PositionType, CodecType>
+                (*leafIter, descriptor, offset, spread, rand01);
+        }
+    }
+
+    // if interrupted, remove remaining leaf nodes
+    for (; leafIter; ++leafIter) leafIter->setValuesOff();
+
+    tools::pruneInactive(points->tree());
+    if (interrupter) interrupter->end();
+    return points;
+}
+
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+
+#endif // OPENVDB_POINTS_POINT_SCATTER_HAS_BEEN_INCLUDED
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/tools/PointScatter.h
+++ b/openvdb/tools/PointScatter.h
@@ -188,7 +188,7 @@ public:
     // the operator() method was called
     void print(const std::string &name, std::ostream& os = std::cout) const
     {
-        os << "Uniformely scattered " << mPointCount << " points into " << mVoxelCount
+        os << "Uniformly scattered " << mPointCount << " points into " << mVoxelCount
            << " active voxels in \"" << name << "\" corresponding to "
            << mPointsPerVolume << " points per volume." << std::endl;
     }

--- a/openvdb/unittest/TestPointScatter.cc
+++ b/openvdb/unittest/TestPointScatter.cc
@@ -1,0 +1,734 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <random>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <openvdb/openvdb.h>
+
+#include <openvdb/points/PointScatter.h>
+#include <openvdb/points/PointCount.h>
+#include <openvdb/points/PointDataGrid.h>
+
+#include <openvdb/math/Math.h>
+#include <openvdb/math/Coord.h>
+
+using namespace openvdb;
+using namespace openvdb::points;
+
+class TestPointScatter: public CppUnit::TestCase
+{
+public:
+
+    virtual void setUp() { openvdb::initialize(); }
+    virtual void tearDown() { openvdb::uninitialize(); }
+
+    CPPUNIT_TEST_SUITE(TestPointScatter);
+    CPPUNIT_TEST(testUniformPointScatter);
+    CPPUNIT_TEST(testDenseUniformPointScatter);
+    CPPUNIT_TEST(testNonUniformPointScatter);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testUniformPointScatter();
+    void testDenseUniformPointScatter();
+    void testNonUniformPointScatter();
+
+}; // class TestPointScatter
+
+
+void
+TestPointScatter::testUniformPointScatter()
+{
+    const Index64 total = 50;
+    const math::CoordBBox boxBounds(math::Coord(-1), math::Coord(1)); // 27 voxels across 8 leaves
+
+    // Test the free function for all default grid types - 50 points across 27 voxels
+    // ensures all voxels receive points
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        DoubleGrid grid;
+        grid.sparseFill(boxBounds, 0.0, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        FloatGrid grid;
+        grid.sparseFill(boxBounds, 0.0f, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        Int32Grid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        Int64Grid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        MaskGrid grid;
+        grid.sparseFill(boxBounds, /*maskBuffer*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        StringGrid grid;
+        grid.sparseFill(boxBounds, "", /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        Vec3DGrid grid;
+        grid.sparseFill(boxBounds, Vec3d(), /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        Vec3IGrid grid;
+        grid.sparseFill(boxBounds, Vec3i(), /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        Vec3SGrid grid;
+        grid.sparseFill(boxBounds, Vec3f(), /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+    {
+        PointDataGrid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::uniformPointScatter(grid, total);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+    }
+
+    // Test 0 produces empty grid
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::uniformPointScatter(grid, 0);
+        CPPUNIT_ASSERT(points->empty());
+    }
+
+    // Test single point scatter and topology
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::uniformPointScatter(grid, 1);
+        CPPUNIT_ASSERT_EQUAL(Index32(1), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(1), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(1), pointCount(points->tree()));
+    }
+
+    // Test a grid containing tiles scatters correctly
+
+    BoolGrid grid;
+    grid.tree().addTile(/*level*/1, math::Coord(0), /*value*/true, /*active*/true);
+
+    const Index32 NUM_VALUES = BoolGrid::TreeType::LeafNodeType::NUM_VALUES;
+
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES), grid.activeVoxelCount());
+
+    auto points = points::uniformPointScatter(grid, total);
+
+#ifndef OPENVDB_2_ABI_COMPATIBLE
+    CPPUNIT_ASSERT_EQUAL(Index64(0), points->tree().activeTileCount());
+#endif
+    CPPUNIT_ASSERT_EQUAL(Index32(1), points->tree().leafCount());
+    CPPUNIT_ASSERT(Index64(NUM_VALUES) > points->tree().activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+
+    // Explicitly check P attribute
+
+    const auto* attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    const auto* array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+
+    using PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>;
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size_t size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(total), size);
+
+    AttributeHandle<Vec3f, NullCodec>::Ptr pHandle =
+        AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.5f);
+        CPPUNIT_ASSERT(P[0] <= 0.5f);
+        CPPUNIT_ASSERT(P[1] >=-0.5f);
+        CPPUNIT_ASSERT(P[1] <= 0.5f);
+        CPPUNIT_ASSERT(P[2] >=-0.5f);
+        CPPUNIT_ASSERT(P[2] <= 0.5f);
+    }
+
+    // Test the rng seed
+
+    const Vec3f firstPosition = pHandle->get(0);
+    points = points::uniformPointScatter(grid, total, /*seed*/1);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(total), size);
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+
+    const Vec3f secondPosition = pHandle->get(0);
+    CPPUNIT_ASSERT(firstPosition[0] != secondPosition[0]);
+    CPPUNIT_ASSERT(firstPosition[1] != secondPosition[1]);
+    CPPUNIT_ASSERT(firstPosition[2] != secondPosition[2]);
+
+    // Test spread
+
+    points = points::uniformPointScatter(grid, total, /*seed*/1, /*spread*/0.2f);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(total), size);
+
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.2f);
+        CPPUNIT_ASSERT(P[0] <= 0.2f);
+        CPPUNIT_ASSERT(P[1] >=-0.2f);
+        CPPUNIT_ASSERT(P[1] <= 0.2f);
+        CPPUNIT_ASSERT(P[2] >=-0.2f);
+        CPPUNIT_ASSERT(P[2] <= 0.2f);
+    }
+
+    // Test mt11213b
+
+    using mt11213b = std::mersenne_twister_engine<uint32_t, 32, 351, 175, 19,
+        0xccab8ee7, 11, 0xffffffff, 7, 0x31b6ab00, 15, 0xffe50000, 17, 1812433253>;
+
+    points = points::uniformPointScatter<BoolGrid, mt11213b>(grid, total);
+
+    CPPUNIT_ASSERT_EQUAL(Index32(1), points->tree().leafCount());
+    CPPUNIT_ASSERT(Index64(NUM_VALUES) > points->tree().activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(total, pointCount(points->tree()));
+
+    // Test no remainder - grid contains one tile, scatter NUM_VALUES points
+
+    points = points::uniformPointScatter(grid, Index64(NUM_VALUES));
+
+    CPPUNIT_ASSERT_EQUAL(Index32(1), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES), pointCount(points->tree()));
+
+    const auto* const leaf = points->tree().probeConstLeaf(math::Coord(0));
+    CPPUNIT_ASSERT(leaf);
+    CPPUNIT_ASSERT(leaf->isDense());
+
+    const auto* const data = leaf->buffer().data();
+    CPPUNIT_ASSERT_EQUAL(Index32(1), Index32(data[1] - data[0]));
+
+    for (size_t i = 1; i < NUM_VALUES; ++i) {
+        const Index32 offset = data[i] - data[i - 1];
+        CPPUNIT_ASSERT_EQUAL(Index32(1), offset);
+    }
+}
+
+void
+TestPointScatter::testDenseUniformPointScatter()
+{
+    const Index32 pointsPerVoxel = 8;
+    const math::CoordBBox boxBounds(math::Coord(-1), math::Coord(1)); // 27 voxels across 8 leaves
+
+    // Test the free function for all default grid types
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        DoubleGrid grid;
+        grid.sparseFill(boxBounds, 0.0, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        FloatGrid grid;
+        grid.sparseFill(boxBounds, 0.0f, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Int32Grid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Int64Grid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        MaskGrid grid;
+        grid.sparseFill(boxBounds, /*maskBuffer*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        StringGrid grid;
+        grid.sparseFill(boxBounds, "", /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Vec3DGrid grid;
+        grid.sparseFill(boxBounds, Vec3d(), /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Vec3IGrid grid;
+        grid.sparseFill(boxBounds, Vec3i(), /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Vec3SGrid grid;
+        grid.sparseFill(boxBounds, Vec3f(), /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        PointDataGrid grid;
+        grid.sparseFill(boxBounds, 0, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+
+    // Test 0 produces empty grid
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, 0.0f);
+        CPPUNIT_ASSERT(points->empty());
+    }
+
+    // Test topology between 0 - 1
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(boxBounds, false, /*active*/true);
+        auto points = points::denseUniformPointScatter(grid, 0.8f);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        // Note that a value of 22 is precomputed as the number of active
+        // voxels/points produced by a value of 0.8
+        CPPUNIT_ASSERT_EQUAL(Index64(22), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(22), pointCount(points->tree()));
+
+        // Test below 0 throws
+
+        CPPUNIT_ASSERT_THROW(points::denseUniformPointScatter(grid, -0.1f), openvdb::ValueError);
+    }
+
+    // Test a grid containing tiles scatters correctly
+
+    BoolGrid grid;
+    grid.tree().addTile(/*level*/1, math::Coord(0), /*value*/true, /*active*/true);
+    grid.tree().setValueOn(math::Coord(8,0,0)); // add another leaf
+
+    const Index32 NUM_VALUES = BoolGrid::TreeType::LeafNodeType::NUM_VALUES;
+
+    CPPUNIT_ASSERT_EQUAL(Index32(1), grid.tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), grid.activeVoxelCount());
+
+    auto points = points::denseUniformPointScatter(grid, pointsPerVoxel);
+
+    const Index64 expectedCount = Index64(pointsPerVoxel * (NUM_VALUES + 1));
+
+#ifndef OPENVDB_2_ABI_COMPATIBLE
+    CPPUNIT_ASSERT_EQUAL(Index64(0), points->tree().activeTileCount());
+#endif
+    CPPUNIT_ASSERT_EQUAL(Index32(2), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(expectedCount, pointCount(points->tree()));
+
+    // Explicitly check P attribute
+
+    const auto* attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    const auto* array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+
+    using PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>;
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size_t size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+
+    AttributeHandle<Vec3f, NullCodec>::Ptr pHandle =
+        AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.5f);
+        CPPUNIT_ASSERT(P[0] <= 0.5f);
+        CPPUNIT_ASSERT(P[1] >=-0.5f);
+        CPPUNIT_ASSERT(P[1] <= 0.5f);
+        CPPUNIT_ASSERT(P[2] >=-0.5f);
+        CPPUNIT_ASSERT(P[2] <= 0.5f);
+    }
+
+    // Test the rng seed
+
+    const Vec3f firstPosition = pHandle->get(0);
+    points = points::denseUniformPointScatter(grid, pointsPerVoxel, /*seed*/1);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+
+    const Vec3f secondPosition = pHandle->get(0);
+    CPPUNIT_ASSERT(firstPosition[0] != secondPosition[0]);
+    CPPUNIT_ASSERT(firstPosition[1] != secondPosition[1]);
+    CPPUNIT_ASSERT(firstPosition[2] != secondPosition[2]);
+
+    // Test spread
+
+    points = points::denseUniformPointScatter(grid, pointsPerVoxel, /*seed*/1, /*spread*/0.2f);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.2f);
+        CPPUNIT_ASSERT(P[0] <= 0.2f);
+        CPPUNIT_ASSERT(P[1] >=-0.2f);
+        CPPUNIT_ASSERT(P[1] <= 0.2f);
+        CPPUNIT_ASSERT(P[2] >=-0.2f);
+        CPPUNIT_ASSERT(P[2] <= 0.2f);
+    }
+
+    // Test mt11213b
+
+    using mt11213b = std::mersenne_twister_engine<uint32_t, 32, 351, 175, 19,
+        0xccab8ee7, 11, 0xffffffff, 7, 0x31b6ab00, 15, 0xffe50000, 17, 1812433253>;
+
+    points = points::denseUniformPointScatter<BoolGrid, mt11213b>(grid, pointsPerVoxel);
+
+    CPPUNIT_ASSERT_EQUAL(Index32(2), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(expectedCount, pointCount(points->tree()));
+}
+
+void
+TestPointScatter::testNonUniformPointScatter()
+{
+    const Index32 pointsPerVoxel = 8;
+    const math::CoordBBox totalBoxBounds(math::Coord(-2), math::Coord(2)); // 125 voxels across 8 leaves
+    const math::CoordBBox activeBoxBounds(math::Coord(-1), math::Coord(1)); // 27 voxels across 8 leaves
+
+    // Test the free function for all default scalar grid types
+
+    {
+        BoolGrid grid;
+        grid.sparseFill(totalBoxBounds, false, /*active*/true);
+        grid.sparseFill(activeBoxBounds, true, /*active*/true);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        DoubleGrid grid;
+        grid.sparseFill(totalBoxBounds, 0.0, /*active*/true);
+        grid.sparseFill(activeBoxBounds, 1.0, /*active*/true);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        FloatGrid grid;
+        grid.sparseFill(totalBoxBounds, 0.0f, /*active*/true);
+        grid.sparseFill(activeBoxBounds, 1.0f, /*active*/true);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Int32Grid grid;
+        grid.sparseFill(totalBoxBounds, 0, /*active*/true);
+        grid.sparseFill(activeBoxBounds, 1, /*active*/true);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        Int64Grid grid;
+        grid.sparseFill(totalBoxBounds, 0, /*active*/true);
+        grid.sparseFill(activeBoxBounds, 1, /*active*/true);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+    {
+        MaskGrid grid;
+        grid.sparseFill(totalBoxBounds, /*maskBuffer*/0);
+        grid.sparseFill(activeBoxBounds, /*maskBuffer*/1);
+        auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+        CPPUNIT_ASSERT_EQUAL(Index32(8), points->tree().leafCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(27), points->activeVoxelCount());
+        CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 27), pointCount(points->tree()));
+    }
+
+    BoolGrid grid;
+
+    // Test below 0 throws
+
+    CPPUNIT_ASSERT_THROW(points::nonUniformPointScatter(grid, -0.1f), openvdb::ValueError);
+
+    // Test a grid containing tiles scatters correctly
+
+    grid.tree().addTile(/*level*/1, math::Coord(0), /*value*/true, /*active*/true);
+    grid.tree().setValueOn(math::Coord(8,0,0), true); // add another leaf
+
+    const Index32 NUM_VALUES = BoolGrid::TreeType::LeafNodeType::NUM_VALUES;
+
+    CPPUNIT_ASSERT_EQUAL(Index32(1), grid.tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), grid.activeVoxelCount());
+
+    auto points = points::nonUniformPointScatter(grid, pointsPerVoxel);
+
+    const Index64 expectedCount = Index64(pointsPerVoxel * (NUM_VALUES + 1));
+
+#ifndef OPENVDB_2_ABI_COMPATIBLE
+    CPPUNIT_ASSERT_EQUAL(Index64(0), points->tree().activeTileCount());
+#endif
+    CPPUNIT_ASSERT_EQUAL(Index32(2), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(expectedCount, pointCount(points->tree()));
+
+    // Explicitly check P attribute
+
+    const auto* attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    const auto* array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+
+    using PositionArrayT = TypedAttributeArray<Vec3f, NullCodec>;
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size_t size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+
+    AttributeHandle<Vec3f, NullCodec>::Ptr pHandle =
+        AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.5f);
+        CPPUNIT_ASSERT(P[0] <= 0.5f);
+        CPPUNIT_ASSERT(P[1] >=-0.5f);
+        CPPUNIT_ASSERT(P[1] <= 0.5f);
+        CPPUNIT_ASSERT(P[2] >=-0.5f);
+        CPPUNIT_ASSERT(P[2] <= 0.5f);
+    }
+
+    // Test the rng seed
+
+    const Vec3f firstPosition = pHandle->get(0);
+    points = points::nonUniformPointScatter(grid, pointsPerVoxel, /*seed*/1);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+
+    const Vec3f secondPosition = pHandle->get(0);
+    CPPUNIT_ASSERT(firstPosition[0] != secondPosition[0]);
+    CPPUNIT_ASSERT(firstPosition[1] != secondPosition[1]);
+    CPPUNIT_ASSERT(firstPosition[2] != secondPosition[2]);
+
+    // Test spread
+
+    points = points::nonUniformPointScatter(grid, pointsPerVoxel, /*seed*/1, /*spread*/0.2f);
+
+    attributeSet = &(points->tree().cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), attributeSet->size());
+    array = attributeSet->getConst(0);
+    CPPUNIT_ASSERT(array);
+    CPPUNIT_ASSERT(array->isType<PositionArrayT>());
+
+    size = array->size();
+    CPPUNIT_ASSERT_EQUAL(size_t(pointsPerVoxel * NUM_VALUES), size);
+
+    pHandle = AttributeHandle<Vec3f, NullCodec>::create(*array);
+    for (size_t i = 0; i < size; ++i) {
+        const Vec3f P = pHandle->get(i);
+        CPPUNIT_ASSERT(P[0] >=-0.2f);
+        CPPUNIT_ASSERT(P[0] <= 0.2f);
+        CPPUNIT_ASSERT(P[1] >=-0.2f);
+        CPPUNIT_ASSERT(P[1] <= 0.2f);
+        CPPUNIT_ASSERT(P[2] >=-0.2f);
+        CPPUNIT_ASSERT(P[2] <= 0.2f);
+    }
+
+    // Test varying counts
+
+    Int32Grid countGrid;
+
+    // tets negative values equate to 0
+    countGrid.tree().setValueOn(Coord(0), -1);
+    for (size_t i = 1; i < 8; ++i) {
+        countGrid.tree().setValueOn(Coord(i), i);
+    }
+
+    points = points::nonUniformPointScatter(countGrid, pointsPerVoxel);
+
+    CPPUNIT_ASSERT_EQUAL(Index32(1), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(7), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(pointsPerVoxel * 28), pointCount(points->tree()));
+
+    for (size_t i = 1; i < 8; ++i) {
+        CPPUNIT_ASSERT(points->tree().isValueOn(Coord(i)));
+        auto& value = points->tree().getValue(Coord(i));
+        Index32 expected(0);
+        for (size_t j = i; j > 0; --j) expected += j;
+        CPPUNIT_ASSERT_EQUAL(Index32(expected * pointsPerVoxel), Index32(value));
+    }
+
+    // Test mt11213b
+
+    using mt11213b = std::mersenne_twister_engine<uint32_t, 32, 351, 175, 19,
+        0xccab8ee7, 11, 0xffffffff, 7, 0x31b6ab00, 15, 0xffe50000, 17, 1812433253>;
+
+    points = points::nonUniformPointScatter<BoolGrid, mt11213b>(grid, pointsPerVoxel);
+
+    CPPUNIT_ASSERT_EQUAL(Index32(2), points->tree().leafCount());
+    CPPUNIT_ASSERT_EQUAL(Index64(NUM_VALUES + 1), points->activeVoxelCount());
+    CPPUNIT_ASSERT_EQUAL(expectedCount, pointCount(points->tree()));
+}
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestPointScatter);
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -38,6 +38,8 @@
 #include <houdini_utils/ParmFactory.h>
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
+#include <openvdb/points/PointScatter.h>
+#include <openvdb/points/PointGroup.h>
 #include <openvdb/tools/PointScatter.h>
 #include <openvdb/tools/LevelSetUtil.h>
 #include <boost/algorithm/string/join.hpp>
@@ -88,6 +90,16 @@ newSopOperator(OP_OperatorTable* table)
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "keep", "Keep Input VDBs")
         .setDefault(PRMzeroDefaults)
         .setTooltip("If enabled, the output will contain the input VDB grids."));
+
+    // Enable VDB Points
+    parms.add(hutil::ParmFactory(PRM_TOGGLE, "vdbpoints", "Scatter VDB Points")
+        .setDefault(PRMzeroDefaults)
+        .setTooltip("Generate VDB Points instead of Houdini Points."));
+
+    // VDB points grid name
+    parms.add(hutil::ParmFactory(PRM_STRING, "name", "VDB Name")
+        .setDefault("points")
+        .setTooltip("The name of the VDB Points primitive to be created"));
 
     // Group scattered points
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "dogroup", "")
@@ -143,13 +155,15 @@ newSopOperator(OP_OperatorTable* table)
     // Point density
     parms.add(hutil::ParmFactory(PRM_FLT_J, "density", "Density")
         .setDefault(PRMoneDefaults)
-        .setRange(PRM_RANGE_RESTRICTED, 0, PRM_RANGE_UI, 10)
+        .setRange(PRM_RANGE_RESTRICTED, 0, PRM_RANGE_UI, 1000)
         .setTooltip("The number of points per unit volume (when __Mode__ is Point Density)"));
 
     // Toggle to use voxel value as local point density multiplier
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "multiply", "Scale Density by Voxel Values")
         .setDefault(PRMzeroDefaults)
-        .setTooltip("If enabled, use voxel values as local multipliers for the point density."));
+        .setTooltip(
+            "If enabled, use voxel values as local multipliers for the point density."
+            " Has no impact if interior scattering is enabled."));
 
     // Points per voxel
     parms.add(hutil::ParmFactory(PRM_FLT_J , "ppv", "Count")
@@ -163,6 +177,12 @@ newSopOperator(OP_OperatorTable* table)
         .setTooltip(
             "If enabled, scatter points in the interior region of a level set."
             " Otherwise, scatter points only in the narrow band."));
+
+    // an iso-surface offset for interior scattering
+    parms.add(hutil::ParmFactory(PRM_FLT_J, "offset", "Offset")
+        .setDefault(PRMzeroDefaults)
+        .setRange(PRM_RANGE_UI, -1.0f, PRM_RANGE_UI, 1.0f)
+        .setTooltip("The offset at which to interpret the iso surface."));
 
     parms.add(hutil::ParmFactory(PRM_SEPARATOR, "sep2", ""));
 
@@ -183,11 +203,13 @@ newSopOperator(OP_OperatorTable* table)
 #icon: COMMON/openvdb\n\
 #tags: vdb\n\
 \n\
-\"\"\"Scatter points on a VDB volume.\"\"\"\n\
+\"\"\"Scatter Houdini or VDB points on a VDB volume.\"\"\"\n\
 \n\
 @overview\n\
 \n\
-This node scatters points randomly on or inside a VDB volume.\n\
+This node scatters points randomly on or inside a VDB volume. It can produce a set\n\
+of Houdini points or a VDB Points grid for every provided VDB. Each VDB Points grid\n\
+created will copy the transform and topology of each source VDB.\n\
 The number of points generated can be specified either by fixed count\n\
 or by global or local point density.\n\
 \n\
@@ -222,12 +244,16 @@ bool
 SOP_OpenVDB_Scatter::updateParmsFlags()
 {
     bool changed = false;
+    const auto vdbpoints = evalInt("vdbpoints", /*idx=*/0, /*time=*/0);
     const auto pmode = evalInt("pointmode", /*idx=*/0, /*time=*/0);
+    const auto interior = evalInt("interior", /*idx=*/0, /*time=*/0);
 
     changed |= setVisibleState("count",    (0 == pmode));
     changed |= setVisibleState("density",  (1 == pmode));
     changed |= setVisibleState("multiply", (1 == pmode));
     changed |= setVisibleState("ppv",      (2 == pmode));
+    changed |= setVisibleState("name",     (1 == vdbpoints));
+    changed |= enableParm("offset", interior);
 
     const auto dogroup = evalInt("dogroup", 0, 0);
     changed |= enableParm("sgroup", 1 == dogroup);
@@ -273,32 +299,160 @@ protected:
 };
 
 
-// Method to extract the interior mask before scattering points.
-template<typename OpType>
-bool
-processLSInterior(UT_VDBType gridType, const openvdb::GridBase& gridRef, OpType& op)
+struct BaseScatter
 {
-    if (gridType == UT_VDB_FLOAT) {
-        const openvdb::FloatGrid* grid = static_cast<const openvdb::FloatGrid*>(&gridRef);
-        if (grid == nullptr) return false;
+    using PositionArray =
+        openvdb::points::TypedAttributeArray<openvdb::Vec3f, openvdb::points::NullCodec>;
 
-        typename openvdb::Grid<typename openvdb::FloatTree::template ValueConverter<bool>::Type>::Ptr maskGrid;
-        maskGrid = openvdb::tools::sdfInteriorMask(*grid);
-        op(*maskGrid);
+    BaseScatter(const unsigned int seed,
+                const float spread,
+                hvdb::Interrupter* interrupter)
+        : mPoints()
+        , mSeed(seed)
+        , mSpread(spread)
+        , mInterrupter(interrupter) {}
 
-        return true;
-
-    } else if (gridType == UT_VDB_DOUBLE) {
-        const openvdb::DoubleGrid* grid = static_cast<const openvdb::DoubleGrid*>(&gridRef);
-        if (grid == nullptr) return false;
-
-        typename openvdb::Grid<typename openvdb::DoubleTree::template ValueConverter<bool>::Type>::Ptr maskGrid;
-        maskGrid = openvdb::tools::sdfInteriorMask(*grid);
-        op(*maskGrid);
-
-        return true;
+    /// @brief Print information about the scattered points
+    /// @parm name  A name to insert into the printed info
+    /// @parm os    The output stream
+    virtual void print(const std::string &name, std::ostream& os = std::cout) const
+    {
+        if (!mPoints) return;
+        const openvdb::Index64 points = openvdb::points::pointCount(mPoints->tree());
+        const openvdb::Index64 voxels = mPoints->activeVoxelCount();
+        os << points << " points into " << voxels << " active voxels in \""
+           << name << "\" corresponding to " << (double(points) / double(voxels))
+           << " points per voxel." << std::endl;
     }
-    return false;
+
+    inline openvdb::points::PointDataGrid::Ptr points()
+    {
+        assert(mPoints);
+        return mPoints;
+    }
+
+protected:
+    openvdb::points::PointDataGrid::Ptr mPoints;
+    const unsigned int mSeed;
+    const float mSpread;
+    hvdb::Interrupter* mInterrupter;
+}; // BaseScatter
+
+
+struct VDBUniformScatter : public BaseScatter
+{
+    VDBUniformScatter(const openvdb::Index64 count,
+                      const unsigned int seed,
+                      const float spread,
+                      hvdb::Interrupter* interrupter)
+        : mCount(count)
+        , BaseScatter(seed, spread, interrupter) {}
+
+    template <typename GridT>
+    inline void operator()(const GridT& grid)
+    {
+        using namespace openvdb::points;
+        using PointDataGridT = openvdb::Grid<typename TreeConverter<typename GridT::TreeType>::Type>;
+        mPoints = uniformPointScatter<GridT, std::mt19937, PositionArray, PointDataGridT,
+                hvdb::Interrupter>(grid, mCount, mSeed, mSpread, mInterrupter);
+    }
+
+    void print(const std::string &name, std::ostream& os = std::cout) const
+    {
+        os << "Uniformly scattered ";
+        BaseScatter::print(name, os);
+    }
+    const openvdb::Index64 mCount;
+}; // VDBUniformScatter
+
+
+struct VDBDenseUniformScatter : public BaseScatter
+{
+    VDBDenseUniformScatter(const float pointsPerVoxel,
+                           const unsigned int seed,
+                           const float spread,
+                           hvdb::Interrupter* interrupter)
+        : mPointsPerVoxel(pointsPerVoxel)
+        , BaseScatter(seed, spread, interrupter) {}
+
+    template <typename GridT>
+    inline void operator()(const GridT& grid)
+    {
+        using namespace openvdb::points;
+        using PointDataGridT = openvdb::Grid<typename TreeConverter<typename GridT::TreeType>::Type>;
+        mPoints = denseUniformPointScatter<GridT, std::mt19937, PositionArray, PointDataGridT,
+                hvdb::Interrupter>(grid, mPointsPerVoxel, mSeed, mSpread, mInterrupter);
+    }
+
+    void print(const std::string &name, std::ostream& os = std::cout) const
+    {
+        os << "Dense uniformly scattered ";
+        BaseScatter::print(name, os);
+    }
+    const float mPointsPerVoxel;
+}; // VDBDenseUniformScatter
+
+
+struct VDBNonUniformScatter : public BaseScatter
+{
+    VDBNonUniformScatter(const float pointsPerVoxel,
+                      const unsigned int seed,
+                      const float spread,
+                      hvdb::Interrupter* interrupter)
+        : mPointsPerVoxel(pointsPerVoxel)
+        , BaseScatter(seed, spread, interrupter) {}
+
+    template <typename GridT>
+    inline void operator()(const GridT& grid)
+    {
+        using namespace openvdb::points;
+        using PointDataGridT = openvdb::Grid<typename TreeConverter<typename GridT::TreeType>::Type>;
+        mPoints = nonUniformPointScatter<GridT, std::mt19937, PositionArray, PointDataGridT,
+                hvdb::Interrupter>(grid, mPointsPerVoxel, mSeed, mSpread, mInterrupter);
+    }
+
+    void print(const std::string &name, std::ostream& os = std::cout) const
+    {
+        os << "Non-uniformly scattered ";
+        BaseScatter::print(name, os);
+    }
+    const float mPointsPerVoxel;
+}; // VDBNonUniformScatter
+
+
+template<typename OpType>
+inline bool
+process(const UT_VDBType type, const openvdb::GridBase& grid, OpType& op, const std::string* name)
+{
+    bool success(false);
+    success = UTvdbProcessTypedGridTopology(type, grid, op);
+    if (!success) {
+#if UT_MAJOR_VERSION_INT >= 16
+        success = UTvdbProcessTypedGridPoint(type, grid, op);
+#endif
+    }
+    if (name) op.print(*name);
+    return success;
+}
+
+
+// Method to extract the interior mask before scattering points.
+openvdb::GridBase::ConstPtr
+extractInteriorMask(const openvdb::GridBase::ConstPtr grid, const float offset)
+{
+    if (grid->isType<openvdb::FloatGrid>()) {
+        using MaskT = openvdb::Grid<openvdb::FloatTree::ValueConverter<bool>::Type>;
+        const openvdb::FloatGrid& typedGrid = static_cast<const openvdb::FloatGrid&>(*grid);
+        MaskT::Ptr mask = openvdb::tools::sdfInteriorMask(typedGrid, offset);
+        return mask;
+
+    } else if (grid->isType<openvdb::DoubleGrid>()) {
+        using MaskT = openvdb::Grid<openvdb::DoubleTree::ValueConverter<bool>::Type>;
+        const openvdb::DoubleGrid& typedGrid = static_cast<const openvdb::DoubleGrid&>(*grid);
+        MaskT::Ptr mask = openvdb::tools::sdfInteriorMask(typedGrid, offset);
+        return mask;
+    }
+    return openvdb::GridBase::ConstPtr();
 }
 
 
@@ -312,27 +466,37 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
         hutil::ScopedInputLock lock(*this, context);
         const fpreal time = context.getTime();
 
-        const GU_Detail* vdbgeo = inputGeo(0);
+        const GU_Detail* vdbgeo;
+        if (1 == evalInt("keep", 0, time)) {
+            // This does a deep copy of native Houdini primitives
+            // but only a shallow copy of OpenVDB grids.
+            duplicateSourceStealable(0, context);
+            vdbgeo = gdp;
+        }
+        else {
+            vdbgeo = inputGeo(0);
+            gdp->clearAndDestroy();
+        }
 
-        gdp->clearAndDestroy();
-
-        const int seed = static_cast<int>(evalInt("seed", /*idx=*/0, time));
-        const double spread = evalFloat("spread", 0, time);
-        const bool verbose   = evalInt("verbose", /*idx=*/0, time) != 0;
+        const int seed = static_cast<int>(evalInt("seed", 0, time));
+        const double spread = static_cast<double>(evalFloat("spread", 0, time));
+        const bool verbose = evalInt("verbose", 0, time) != 0;
         const openvdb::Index64 pointCount = evalInt("count", 0, time);
-        const float density  = static_cast<float>(evalFloat("density", 0, time));
         const float ptsPerVox = static_cast<float>(evalFloat("ppv", 0, time));
-        const bool interior  = evalInt("interior", /*idx=*/0, time) != 0;
-
+        const bool interior = evalInt("interior", 0, time) != 0;
+        const float offset = static_cast<float>(evalFloat("offset", 0, time));
+        const float density = static_cast<float>(evalFloat("density", 0, time));
+        const bool multiplyDensity = evalInt("multiply", 0, time) != 0;
 
         // Get the group of grids to process.
-        UT_String groupStr;
-        evalString(groupStr, "group", 0, time);
+        UT_String tmp;
+        evalString(tmp, "group", 0, time);
         const GA_PrimitiveGroup* group
-            = this->matchGroup(const_cast<GU_Detail&>(*vdbgeo), groupStr.toStdString());
+            = this->matchGroup(const_cast<GU_Detail&>(*vdbgeo), tmp.toStdString());
 
+        evalString(tmp, "name", 0, time);
+        const std::string vdbName = tmp.toStdString();
         hvdb::Interrupter boss("OpenVDB Scatter");
-        PointAccessor points(gdp);
 
         // Choose a fast random generator with a long period. Drawback here for
         // mt11213b is that it requires 352*sizeof(uint32) bytes.
@@ -341,96 +505,100 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
         RandGen mtRand(seed);
 
         const auto pmode = evalInt("pointmode", 0, time);
+        const bool vdbPoints = evalInt("vdbpoints", 0, time) == 1;
 
         std::vector<std::string> emptyGrids;
+        std::vector<openvdb::points::PointDataGrid::Ptr> pointGrids;
+        PointAccessor pointAccessor(gdp);
 
         // Process each VDB primitive (with a non-null grid pointer)
         // that belongs to the selected group.
         for (hvdb::VdbPrimCIterator primIter(vdbgeo, group); primIter; ++primIter) {
 
             // Retrieve a read-only grid pointer.
-            hvdb::GridCRef grid = primIter->getGrid();
             UT_VDBType gridType = primIter->getStorageType();
-            const openvdb::GridClass gridClass = grid.getGridClass();
-            const bool isSignedDistance = (gridClass == openvdb::GRID_LEVEL_SET);
+            openvdb::GridBase::ConstPtr grid = primIter->getConstGridPtr();
             const std::string gridName = primIter.getPrimitiveName().toStdString();
 
-            if (grid.empty()) {
+            if (grid->empty()) {
                 emptyGrids.push_back(gridName);
                 continue;
             }
 
+            const std::string* const name = verbose ? &gridName : nullptr;
+            const openvdb::GridClass gridClass = grid->getGridClass();
+            const bool isSignedDistance = (gridClass == openvdb::GRID_LEVEL_SET);
+
+            if (interior && isSignedDistance) {
+                grid = extractInteriorMask(grid, offset);
+                gridType = UT_VDB_BOOL;
+                if (!grid) continue;
+            }
+
             if (pmode == 0) { // fixed point count
-
-                openvdb::tools::UniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
-                    scatter(points, pointCount, mtRand, spread, &boss);
-
-                if (interior && isSignedDistance) {
-                    processLSInterior(gridType, grid, scatter);
-                } else {
-                    if (!UTvdbProcessTypedGridScalar(gridType, grid, scatter)) {
-#if UT_MAJOR_VERSION_INT >= 16
-                        UTvdbProcessTypedGridPoint(gridType, grid, scatter);
-#endif
+                if (vdbPoints) { // vdb points
+                    VDBUniformScatter scatter(pointCount, seed, spread, &boss);
+                    if (process(gridType, *grid, scatter, name))  {
+                        pointGrids.push_back(scatter.points());
                     }
                 }
-
-                if (verbose) scatter.print(gridName);
+                else { // houdini points
+                    openvdb::tools::UniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
+                        scatter(pointAccessor, pointCount, mtRand, spread, &boss);
+                    process(gridType, *grid, scatter, name);
+                }
 
             } else if (pmode == 1) { // points per unit volume
-
-                if (evalInt("multiply", 0, time) != 0) { // local density
-                    openvdb::tools::NonUniformPointScatter<PointAccessor,RandGen,hvdb::Interrupter>
-                        scatter(points, density, mtRand, spread, &boss);
-
-
-                    if (interior && isSignedDistance) {
-                        processLSInterior(gridType, grid, scatter);
-                    } else {
-
-                        if (!UTvdbProcessTypedGridScalar(gridType, grid, scatter)) {
+                if (multiplyDensity && !isSignedDistance) { // local density
+                    if (vdbPoints) { // vdb points
+                        const openvdb::Vec3d dim = openvdb::Vec3f(grid->transform().voxelSize());
+                        VDBNonUniformScatter scatter(density * dim.product(), seed, spread, &boss);
+                        if (!UTvdbProcessTypedGridScalar(gridType, *grid, scatter)) {
                             throw std::runtime_error
                                 ("Only scalar grids support voxel scaling of density");
                         }
+                        pointGrids.push_back(scatter.points());
+                        if (verbose) scatter.print(gridName);
                     }
+                    else { // houdini points
+                        openvdb::tools::NonUniformPointScatter<PointAccessor,RandGen,hvdb::Interrupter>
+                            scatter(pointAccessor, density, mtRand, spread, &boss);
 
-                    if (verbose) scatter.print(gridName);
-
+                        if (!UTvdbProcessTypedGridScalar(gridType, *grid, scatter)) {
+                            throw std::runtime_error
+                                ("Only scalar grids support voxel scaling of density");
+                        }
+                        if (verbose) scatter.print(gridName);
+                    }
                 } else { // global density
-                    openvdb::tools::UniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
-                        scatter(points, density, mtRand, spread, &boss);
-
-                    if (interior && isSignedDistance) {
-                        processLSInterior(gridType, grid, scatter);
-                    } else {
-                        if (!UTvdbProcessTypedGridTopology(gridType, grid, scatter)) {
-#if UT_MAJOR_VERSION_INT >= 16
-                            UTvdbProcessTypedGridPoint(gridType, grid, scatter);
-#endif
+                    if (vdbPoints) { // vdb points
+                        const openvdb::Vec3f dim = openvdb::Vec3f(grid->transform().voxelSize());
+                        const openvdb::Index64 totalPointCount =
+                            openvdb::Index64(density * dim.product()) * grid->activeVoxelCount();
+                        VDBUniformScatter scatter(totalPointCount, seed, spread, &boss);
+                        if (process(gridType, *grid, scatter, name))  {
+                            pointGrids.push_back(scatter.points());
                         }
                     }
-
-                    if (verbose) scatter.print(gridName);
-                }
-
-            } else if (pmode == 2) { // points per voxel
-
-                openvdb::tools::DenseUniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
-                    scatter(points, ptsPerVox, mtRand, spread, &boss);
-
-                if (interior && isSignedDistance) {
-                    processLSInterior(gridType, grid, scatter);
-                } else {
-                    if (!UTvdbProcessTypedGridTopology(gridType, grid, scatter)) {
-#if UT_MAJOR_VERSION_INT >= 16
-                        UTvdbProcessTypedGridPoint(gridType, grid, scatter);
-#endif
+                    else { // houdini points
+                        openvdb::tools::UniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
+                            scatter(pointAccessor, density, mtRand, spread, &boss);
+                        process(gridType, *grid, scatter, name);
                     }
                 }
-
-                if (verbose) scatter.print(gridName);
+            } else if (pmode == 2) { // points per voxel
+                if (vdbPoints) { // vdb points
+                    VDBDenseUniformScatter scatter(ptsPerVox, seed, spread, &boss);
+                    if (process(gridType, *grid, scatter, name))  {
+                        pointGrids.push_back(scatter.points());
+                    }
+                }
+                else { // houdini points
+                    openvdb::tools::DenseUniformPointScatter<PointAccessor, RandGen, hvdb::Interrupter>
+                        scatter(pointAccessor, ptsPerVox, mtRand, spread, &boss);
+                    process(gridType, *grid, scatter, name);
+                }
             }
-
         } // for each grid
 
         if (!emptyGrids.empty()) {
@@ -447,13 +615,17 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
 
             // add ALL the points to this group
             ptgroup->addRange(gdp->getPointRange());
+
+            const std::string groupName(scatterStr.toStdString());
+            for (auto& pointGrid : pointGrids) {
+                openvdb::points::appendGroup(pointGrid->tree(), groupName);
+                openvdb::points::setGroup(pointGrid->tree(), groupName);
+            }
         }
 
-        // add the VDBs to the output if requested
-        if (1 == evalInt("keep", 0, time)) {
-            gdp->mergePrimitives(*vdbgeo, vdbgeo->getPrimitiveRange());
+        for (auto& pointGrid : pointGrids) {
+            hvdb::createVdbPrimitive(*gdp, pointGrid, vdbName.c_str());
         }
-
     }
     catch (std::exception& e) {
         addError(SOP_MESSAGE, e.what());


### PR DESCRIPTION

@danrbailey I've re-written this as discussed. A few things:

 - I've completely re-written the history. If you would prefer this as a set of changes on the old implementation let me know.
 - Note the introduction of value conversion methods in PointDataGrid.h You cannot use ValueConverter the way you suggested as a PointDataLeaf is not a specialised LeafNode type, but instead an derived class.
 - I have yet to remove the level set offset functionality in the SOP. We discussed converting this to a toggle that always does accurtae iso surface scattering however I require the sample functionality for this. I have three options; remove this completely until the sample changers are also open sources, leave it as an offset option or delay this PR and combine with the sample changes.